### PR TITLE
Math.round lead to negative sign not showing

### DIFF
--- a/js_plugins/adei.js
+++ b/js_plugins/adei.js
@@ -69,10 +69,14 @@ function parse_adei(key, value, timestamp, invalid) {
         }
     } else {
         if (data_decimal_numbers != undefined && data_decimal_numbers >= 0) {
-            value = (Math.round(value * 100) / 100).toFixed(data_decimal_numbers);
+            if (value >= 0) {
+                value = (Math.round(value * 100) / 100).toFixed(data_decimal_numbers);
+            } else {
+                // negative value
+                value = ((value * 100) / 100).toFixed(data_decimal_numbers);
+            }
         }
     }
-
 
     if (invalid != undefined && invalid < delta) {
         $("#" + key + "> .value").css('color', 'grey');


### PR DESCRIPTION
Issue: Math.round will round off the value to 0 even though the actual value is -0. 

**Bora 1.0**
![Bora 1 0](https://github.com/kit-ipe/bora/assets/127185216/79600ee0-8b59-4592-a03c-fcadc2cdebb4)

**Bora 2.0 before fixing**
![Bora 2 1](https://github.com/kit-ipe/bora/assets/127185216/7a10813e-8273-4a64-869d-e5e61e64e617)

**Bora 2.0 after fixing**
![bora 2 0](https://github.com/kit-ipe/bora/assets/127185216/77401e8a-6135-4e6e-b049-ca3e9fd4b271)
